### PR TITLE
Fix: bpm input validation

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -123,7 +123,7 @@ export async function updateTrackAction(_: any, formData: FormData) {
   let field = formData.get('field') as string;
   let value = formData.get(field) as keyof typeof songs.$inferInsert | number;
 
-  if (value === 'bpm' && typeof value === "number") {
+  if (value === 'bpm' && typeof value === 'number') {
     value = parseInt(value as string);
   } else{
     return { success: false, error: 'bpm should be a valid number' };

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -125,7 +125,7 @@ export async function updateTrackAction(_: any, formData: FormData) {
 
   if (value === 'bpm' && typeof value === 'number') {
     value = parseInt(value as string);
-  } else{
+  } else {
     return { success: false, error: 'bpm should be a valid number' };
   }
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -123,8 +123,10 @@ export async function updateTrackAction(_: any, formData: FormData) {
   let field = formData.get('field') as string;
   let value = formData.get(field) as keyof typeof songs.$inferInsert | number;
 
-  if (value === 'bpm') {
+  if (value === 'bpm' && typeof value === "number") {
     value = parseInt(value as string);
+  } else{
+    return { success: false, error: 'bpm should be a valid number' };
   }
 
   let data: Partial<typeof songs.$inferInsert> = { [field]: value };


### PR DESCRIPTION
input validation is a bit off for BPM input field, 
this PR adds extra check on BPM input field, by checking if the input is number or not.

![image](https://github.com/user-attachments/assets/5d71c273-f9a0-432d-bcc6-2f84e90e712d)


![image](https://github.com/user-attachments/assets/4001f933-35e0-4b50-8042-62b7239548eb)
