### PR TITLE
Add development environment setup (AGENTS.md + pnpm build config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a **Next.js Music Player** — a single full-stack Next.js 16 app (not a monorepo). It uses PostgreSQL via Drizzle ORM, Vercel Blob for file storage, and Tailwind CSS v4 for styling. See `README.md` for feature list and standard commands.
+
+### Services
+
+| Service | How to start | Notes |
+|---------|-------------|-------|
+| PostgreSQL | `sudo docker compose up -d` (from repo root) | Uses `docker-compose.yml` with `postgres:16.4-alpine` on port `54322`. Must have Docker running (`sudo dockerd` if not started). |
+| Next.js dev server | `pnpm dev` | Runs on `http://localhost:3000` with Turbopack. |
+
+### Environment variables
+
+The `.env` file must contain `POSTGRES_URL` and `BLOB_READ_WRITE_TOKEN`. For local dev with Docker Postgres, use `POSTGRES_URL=postgres://postgres:postgres@localhost:54322/postgres`. The `BLOB_READ_WRITE_TOKEN` is only required for file upload features (playlist cover images, song uploads via seed script); the app starts and serves pages without a valid token.
+
+### Database
+
+- **Migrations**: `pnpm db:migrate` (requires `tsx` installed globally: `npm install -g tsx`)
+- **Seed**: `pnpm db:seed` requires `.mp3` files in a `tracks/` directory and a valid `BLOB_READ_WRITE_TOKEN`. For quick dev testing, seed data directly via `psql` into the Docker container.
+- **Studio**: `pnpm db:studio` opens Drizzle Studio for database inspection.
+
+### Build & lint
+
+- **Build**: `pnpm build` — runs TypeScript checking and Next.js production build.
+- **Lint**: No dedicated lint script is configured. TypeScript type-checking runs as part of `pnpm build`.
+- **Dev**: `pnpm dev` — starts the dev server with Turbopack hot reload.
+
+### Gotchas
+
+- The `pnpm db:*` scripts use `npx tsx` which requires `tsx` to be globally installed (`npm install -g tsx`). It is not a project dependency.
+- The `pnpm db:setup` script is interactive (prompts for input). Do not run it in non-interactive mode. Instead, create `.env` and `docker-compose.yml` manually.
+- `pnpm.onlyBuiltDependencies` in `package.json` must include `esbuild` and `sharp` for their native binaries to build correctly during `pnpm install`.
+- Docker requires `fuse-overlayfs` storage driver and `iptables-legacy` in the Cloud Agent VM. Docker daemon must be started with `sudo dockerd &` before running `docker compose up -d`.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,11 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the Next.js Music Player application.

### Changes

- **`AGENTS.md`**: Added Cursor Cloud specific instructions covering services, environment variables, database setup, build/lint commands, and gotchas for future agents.
- **`package.json`**: Added `pnpm.onlyBuiltDependencies` to allow `esbuild` and `sharp` native binary builds during `pnpm install` (previously blocked by pnpm's default build script policy).

### Development environment verified

| Check | Result |
|-------|--------|
| `pnpm install` | Dependencies install with native builds for esbuild/sharp |
| `pnpm build` | TypeScript compiles, Next.js production build succeeds |
| `pnpm dev` | Dev server starts on http://localhost:3000 with Turbopack |
| PostgreSQL (Docker) | Runs via docker-compose on port 54322 |
| `pnpm db:migrate` | Database migrations run successfully |
| Database seeding | Songs, playlists, and playlist-song relationships created |

### Demo

<a href="https://cursor.com/agents/bc-0e51ad42-47e1-4c44-b664-a051376658af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmusic_player_demo.mp4"><img src="https://cursor.com/artifacts/c/art-d9a17d8c-8add-4fdf-a2c8-f0ac0bf013d3" alt="music_player_demo.mp4" /></a>

Music player running with playlist navigation, song selection, and Now Playing panel.

![Music player main view](https://cursor.com/artifacts/c/art-331897b0-c46a-4d79-94a3-766bf6c43c3b)
![Playlist view with tracks](https://cursor.com/artifacts/c/art-a6aa596c-9d5a-4397-8e65-6757347233b0)
![Song selected with Now Playing panel](https://cursor.com/artifacts/c/art-897c5b7c-4880-4936-aae5-ff2223684c44)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e51ad42-47e1-4c44-b664-a051376658af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e51ad42-47e1-4c44-b664-a051376658af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

